### PR TITLE
Hide the hero image on smaller screens

### DIFF
--- a/source/assets/stylesheets/base/_grid-settings.scss
+++ b/source/assets/stylesheets/base/_grid-settings.scss
@@ -1,10 +1,10 @@
-@import "neat-helpers"; // or "../neat/neat-helpers" when not in Rails
+@import 'neat-helpers'; // or "../neat/neat-helpers" when not in Rails
 
 // Neat Overrides
 // $column: 90px;
 // $gutter: 30px;
 // $grid-columns: 12;
-$max-width: em(1200);
+$max-width: em(1090);
 
 // Neat Breakpoints
 $medium-screen: em(640);

--- a/source/assets/stylesheets/modules/_hero.scss
+++ b/source/assets/stylesheets/modules/_hero.scss
@@ -63,6 +63,7 @@ to {
 
 .logo {
   @include span-columns(1);
+
   background: none;
   color: $base-accent-color;
   display: inline-block;
@@ -125,20 +126,24 @@ to {
 }
 
 .hero-content-image-background {
-  @include span-columns(6);
-  background-image: image-url("iphone.png");
-  background-repeat: no-repeat;
-  background-size: em(360);
-  float: right;
-  height: 100%;
-  position: absolute;
-  width: em(380);
-}
+  display: none;
 
-.hero-content-image-main {
-  background-image: image-url("iphone-screen.png");
-  background-repeat: no-repeat;
-  height: 100%;
-  margin-left: em(29);
-  margin-top: em(105);
+  @include media($large-screen-up) {
+    @include span-columns(6);
+    background-image: image-url('iphone.png');
+    background-repeat: no-repeat;
+    background-size: em(360);
+    float: right;
+    height: 100%;
+    position: absolute;
+    width: em(380);
+
+    .hero-content-image-main {
+      background-image: image-url('iphone-screen.png');
+      background-repeat: no-repeat;
+      height: 100%;
+      margin-left: em(29);
+      margin-top: em(105);
+    }
+  }
 }


### PR DESCRIPTION
# Reason for Change
- On mobile browsers, the hero "iPhone" image blocks the hero text.
# Changes
- Hide the image by default, display it for screens bigger than 860px.
# Minor
- Replace double quotes with single in some places.
- Smaller `max-width`.
