### PR TITLE
Reorient "features" on smaller screens

### DIFF
--- a/source/assets/stylesheets/modules/_landing.scss
+++ b/source/assets/stylesheets/modules/_landing.scss
@@ -24,12 +24,15 @@
 }
 
 .features-block-item {
-  @include span-columns(4);
-  display: inline-block;
-}
+  @include span-columns(12 of 12);
 
-.features-block-title {
-  margin-top: em(10);
+  @include media($medium-screen-up) {
+    @include span-columns(4 of 12);
+  }
+
+  .features-block-title {
+    margin-top: em(10);
+  }
 }
 
 .bumper-section {


### PR DESCRIPTION
# Reason for Change
- The three "feature" blocks squish together on smaller screens.
- This makes them hard to read.
# Changes
- Set the width to 12 of 12 if smaller than a medium screen.
- Keep at 4/12ths when large.
# Minor
- Nest the related blocks
