### PR TITLE
Add Google Analytics

### DIFF
--- a/source/assets/javascripts/application.js
+++ b/source/assets/javascripts/application.js
@@ -1,1 +1,0 @@
-//= require_tree .

--- a/source/assets/javascripts/google_analytics.js
+++ b/source/assets/javascripts/google_analytics.js
@@ -1,0 +1,7 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-83718928-1', 'auto');
+ga('send', 'pageview');

--- a/source/partials/_javascript.html.slim
+++ b/source/partials/_javascript.html.slim
@@ -1,2 +1,5 @@
 = javascript_include_tag 'https://code.jquery.com/jquery-2.1.1.min.js'
 = javascript_include_tag 'application'
+
+- if build?
+  = javascript_include_tag 'google_analytics'


### PR DESCRIPTION
# Reason for Change
- We should probably track visitors and conversion analytics.
# Changes
- Add a Google analytics javascript file.
- Load it only when building the source code to prevent false positives.
- Remove the `require_tree .` directive from the manifest js file. We shouldn't load every js file by default.
