### PR TITLE
Add file for Google Search Console verification

### DIFF
--- a/source/google7a8655e586e5368c.html
+++ b/source/google7a8655e586e5368c.html
@@ -1,0 +1,1 @@
+google-site-verification: google7a8655e586e5368c.html


### PR DESCRIPTION
# Reason for Change
- [Google's Search Console](https://www.google.com/webmasters/) (formerly 'Webmaster Tools') wants to verify that I own the site.
# Changes
- Copy their marker file into the `/source` dir.
