### PR TITLE
Clean up the Nav Bar

### DIFF
--- a/source/assets/stylesheets/_global.scss
+++ b/source/assets/stylesheets/_global.scss
@@ -2,3 +2,9 @@ body {
   background-color: $base-background-color;
   color: $dark-gray;
 }
+
+.wrap-container {
+  @include outer-container;
+
+  padding: 0 1rem;
+}

--- a/source/assets/stylesheets/_grid.scss
+++ b/source/assets/stylesheets/_grid.scss
@@ -1,0 +1,19 @@
+.flex-row {
+  display: flex;
+  flex-direction: column;
+
+  @include media($medium-screen-up) {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+
+  &--separate {
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &--around {
+    align-items: baseline;
+    justify-content: space-around;
+  }
+}

--- a/source/assets/stylesheets/application.css.scss
+++ b/source/assets/stylesheets/application.css.scss
@@ -4,5 +4,6 @@
 @import 'base/base';
 @import 'neat';
 
+@import 'grid';
 @import 'global';
 @import 'modules/modules';

--- a/source/assets/stylesheets/base/_grid-settings.scss
+++ b/source/assets/stylesheets/base/_grid-settings.scss
@@ -1,5 +1,11 @@
 @import 'neat-helpers'; // or "../neat/neat-helpers" when not in Rails
 
+// Uncomment to display Neat's grid lines for debugging
+// $visual-grid: true;
+// $visual-grid-color: yellow;
+// $visual-grid-index: front;
+// $visual-grid-opacity: 0.5;
+
 // Neat Overrides
 // $column: 90px;
 // $gutter: 30px;
@@ -10,5 +16,5 @@ $max-width: em(1090);
 $medium-screen: em(640);
 $large-screen: em(860);
 
-$medium-screen-up: new-breakpoint(min-width $medium-screen 4);
-$large-screen-up: new-breakpoint(min-width $large-screen 8);
+$medium-screen-up: new-breakpoint(min-width $medium-screen);
+$large-screen-up: new-breakpoint(min-width $large-screen);

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -22,14 +22,18 @@ $dark-gray: #333;
 $medium-gray: #999;
 $light-gray: #ddd;
 
-$footer-color: $dark-gray;
 $base-accent-color: $dark-gray;
-$secondary-accent-color: $white;
+$secondary-accent-color: $light-gray;
+$hero-text-color: white;
+
+$footer-color: $dark-gray;
 
 // Font Colors
 $base-background-color: #fff;
 $base-font-color: $dark-gray;
 $action-color: $dark-green;
+$highlight-background-color: $medium-gray;
+$highlight-font-color: $white;
 
 // Border
 $base-border-color: $light-gray;

--- a/source/assets/stylesheets/modules/_header.scss
+++ b/source/assets/stylesheets/modules/_header.scss
@@ -1,0 +1,45 @@
+.global-nav {
+  padding: em(5) 0;
+}
+
+.global-nav-container {
+  flex-direction: row;
+}
+
+.logo {
+  @include span-columns(1);
+}
+
+.global-nav-items {
+  @include span-columns(9);
+  @include omega();
+
+  color: $secondary-accent-color;
+  text-align: right;
+  vertical-align: middle;
+}
+
+.global-nav-item {
+  border-radius: $base-border-radius;
+  display: inline-block;
+  margin-right: em(20);
+  padding: 0 em(5);
+
+  &:last-child {
+    margin-right: 0;
+  }
+
+  &:hover {
+    background: $highlight-background-color;
+    color: $highlight-font-color;
+    cursor: pointer;
+  }
+
+  a {
+    color: $dark-gray;
+  }
+}
+
+.global-nav-cta {
+  border: em(1.5) solid $base-accent-color;
+}

--- a/source/assets/stylesheets/modules/_hero.scss
+++ b/source/assets/stylesheets/modules/_hero.scss
@@ -27,54 +27,6 @@
   background: linear-gradient(shade($base-accent-color, 10%), tint($base-accent-color, 50%));
 }
 
-.global-nav {
-  padding: em(20) 0 0;
-}
-
-.global-nav-items {
-  color: $secondary-accent-color;
-  float: right;
-}
-
-.global-nav-item {
-  display: inline-block;
-  margin-right: em(20);
-
-  &:last-child {
-    margin-right: 0;
-  }
-
-  &:hover {
-    border-bottom: em(1.5) solid $secondary-accent-color;
-    cursor: pointer;
-  }
-
-  a {
-    color: $white;
-  }
-}
-
-.global-nav-cta {
-  border: em(1.5) solid $secondary-accent-color;
-  border-radius: em(1);
-  padding: 0 em(5);
-
-  &:hover {
-    background: rgba($secondary-accent-color, 0.3);
-  }
-}
-
-.logo {
-  @include span-columns(1);
-
-  background: none;
-  color: $base-accent-color;
-  display: inline-block;
-  float: left;
-  font-weight: 700;
-  padding: em(2) em(7);
-}
-
 .hero-content {
   @include animation-name(hero);
   @include animation-duration(0.9s);
@@ -89,7 +41,7 @@
 }
 
 .hero-content-text-title {
-  color: $secondary-accent-color;
+  color: $hero-text-color;
   font-size: em(32);
   font-weight: 400;
   margin: 0 0 em(5);
@@ -97,7 +49,7 @@
 }
 
 .hero-content-text-subtitle {
-  color: $secondary-accent-color;
+  color: $hero-text-color;
   font-weight: 300;
 }
 

--- a/source/assets/stylesheets/modules/_landing.scss
+++ b/source/assets/stylesheets/modules/_landing.scss
@@ -1,7 +1,3 @@
-.wrap-container {
-  @include outer-container;
-}
-
 .padding-container {
   padding: em(110) 0;
 }
@@ -19,15 +15,11 @@
   margin-bottom: em(50);
 }
 
-.features-block {
-  margin-bottom: em(50);
-}
-
 .features-block-item {
-  @include span-columns(12 of 12);
+  @include media($large-screen-up) {
+  }
 
   @include media($medium-screen-up) {
-    @include span-columns(4 of 12);
   }
 
   .features-block-title {
@@ -44,7 +36,7 @@
   padding: 0;
 
   @include media($medium-screen-up) {
-    @include span-columns(6 of 12);
+    // @include span-columns(6 of 12);
     @include omega(2n);
     padding: 2em 2em 0;
   }
@@ -68,7 +60,7 @@
   width: 100%;
 
   @include media($medium-screen-up) {
-    @include span-columns(6 of 12);
+    // @include span-columns(6 of 12);
   }
 }
 

--- a/source/assets/stylesheets/modules/_modules.scss
+++ b/source/assets/stylesheets/modules/_modules.scss
@@ -1,2 +1,3 @@
+@import 'header';
 @import 'landing';
 @import 'hero';

--- a/source/layouts/application.html.slim
+++ b/source/layouts/application.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title= current_page.data.title || 'cylinder'
+    title= current_page.data.title || 'Cylinder Digital: Solving Business Problems with Digital Products'
     meta charset='utf-8'
     meta content='IE=edge,chrome=1' http={ equiv: 'X-UA-Compatible' }
     meta name='viewport' content='width=device-width initial-scale=1'
@@ -9,6 +9,7 @@ html
     meta name='google-site-verification' content='eJc0q1CLHq7k3GrVWDbzcEj1cIVnIOFAILKomlfQ6uQ'
 
   body class=page_classes
+    = partial('partials/header')
     = yield
     = partial('partials/footer')
     = partial('partials/javascript')

--- a/source/partials/_header.html.slim
+++ b/source/partials/_header.html.slim
@@ -1,0 +1,17 @@
+nav.global-nav
+  .wrap-container
+    .global-nav-container.flex-row.flex-row--separate
+      .logo
+        =link_to('/')
+          =image_tag('cylinder_gray.png')
+      .global-nav-items
+        ul
+          li.global-nav-item
+            =link_to('/#about')
+              | About
+          li.global-nav-item
+            =link_to('/#faq')
+              | FAQs
+          li.global-nav-item.global-nav-cta
+            =link_to('/#contact-us')
+              | Contact Us

--- a/source/partials/_hero.html.slim
+++ b/source/partials/_hero.html.slim
@@ -1,19 +1,4 @@
 header.hero
-  nav.global-nav
-    .wrap-container
-      .logo
-        =link_to('/')
-          =image_tag('cylinder_gray.png')
-      ul.global-nav-items
-        li.global-nav-item
-          =link_to('/#about')
-            | About
-        li.global-nav-item
-          =link_to('/#faq')
-            | FAQs
-        li.global-nav-item.global-nav-cta
-          =link_to('/#contact-us')
-            | Contact Us
   section.hero-content
     .wrap-container
       .hero-content-text


### PR DESCRIPTION
# Reason for Change
- The nav bar was not responsive.
- The images didn't resize correctly.
# Changes
- Extract header partial template and stylesheet.
- Add a `grid` stylesheet to hold grid reformatting elements like flexboxes.
# Minor
- Rename some colors.
- Add debugging gridlines.
- Move `.wrap-container` to global
- Remove column overrides so everything is 12 instead of 8
