### PR TITLE
Fix Mobile Responsive on iPhone 5

### DIFF
--- a/source/assets/stylesheets/application.css.scss
+++ b/source/assets/stylesheets/application.css.scss
@@ -1,8 +1,8 @@
 @import 'vendor/normalize';
 
 @import 'bourbon';
-@import 'base/base';
 @import 'neat';
+@import 'base/base';
 
 @import 'grid';
 @import 'global';

--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -6,6 +6,10 @@ body {
   font-size: $base-font-size;
   -webkit-font-smoothing: antialiased;
   line-height: $base-line-height;
+
+  @include media($medium-screen-up) {
+    font-size: $base-font-size * 1.2;
+  }
 }
 
 h1,

--- a/source/assets/stylesheets/modules/_header.scss
+++ b/source/assets/stylesheets/modules/_header.scss
@@ -1,22 +1,37 @@
 .global-nav {
   background-color: $light-gray;
-  padding: em(5) 0;
+  font-size: $base-font-size * 0.8;
+  padding: 0.5em 0;
 }
 
-.global-nav-container {
-  flex-direction: row;
+.wrap-container {
+  max-width: none; // Override the normal wrap-container behavior.
+
+  .global-nav-container {
+    flex-direction: row;
+  }
 }
+
 
 .logo {
   @include span-columns(1);
+
+  @include media($medium-screen-up) {
+    @include shift(1);
+    @include span-columns(1);
+  }
 }
 
 .global-nav-items {
-  @include span-columns(9);
+  @include span-columns(11);
   @include omega();
 
   color: $secondary-accent-color;
   text-align: right;
+
+  @include media($medium-screen-up) {
+    @include span-columns(9);
+  }
 }
 
 .global-nav-item {

--- a/source/assets/stylesheets/modules/_hero.scss
+++ b/source/assets/stylesheets/modules/_hero.scss
@@ -15,11 +15,16 @@ $hero-text-color: $white;
 
 .hero-content-text {
   @include span-columns(6);
+
+  @include media($medium-screen-up) {
+    @include shift(1);
+    @include span-columns(5);
+  }
 }
 
 .hero-content-text-title {
   color: $hero-text-color;
-  font-size: em(32);
+  font-size: $base-font-size * 1.6;
   font-weight: 400;
   margin: 0 0 em(5);
   text-transform: uppercase;
@@ -27,6 +32,7 @@ $hero-text-color: $white;
 
 .hero-content-text-subtitle {
   color: $hero-text-color;
+  font-size: $base-font-size;
   font-weight: 300;
 }
 
@@ -51,4 +57,8 @@ $hero-text-color: $white;
 
 .hero-content-image {
   @include span-columns(6);
+
+  @include media($medium-screen-up) {
+    @include span-columns(5);
+  }
 }


### PR DESCRIPTION
# Reason for Change
- Mobile responsive styles were overlapping on iPhone 5.
# Changes
## Global
- Set the basic typography for large screens as 20% bigger than base (i.e. mobile).
## Nav
- Add a 1-column margin when on large screens.
- Fix the font sizes.
- Remove the `max-width` directive from the `wrap-container` class.
## Hero
- Fix font sizes.
- Add a 1-column margin when on large screens.
# Minor
- Loading `base/base` preset styles should happen after `neat` is loaded.

Before (iPhone 5):
![image](https://cloud.githubusercontent.com/assets/913757/19458507/5ffa4364-9481-11e6-9bde-e1f6362f193c.png)

After (iPhone 5):
![image](https://cloud.githubusercontent.com/assets/913757/19458493/426caf3a-9481-11e6-8fde-204287c64343.png)
