### PR TITLE
Move domains from cylinder.work to cylinder.digital

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-cylinder.work
+cylinder.digital

--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,1 @@
-cylinder.work
+cylinder.digital


### PR DESCRIPTION
Reason for Change
=================
* It's a better TLD and closer aligned with the company name :)
* The email can remain at .work, which is just shorter.

Changes
=======
* Update the `CNAME` files.
* I'm not sure if I need both, but they're both edited for now.