### PR TITLE
Redirect /hello to Calendly

### DIFF
--- a/source/hello.html
+++ b/source/hello.html
@@ -1,0 +1,3 @@
+<head>
+  <meta http-equiv="refresh" content="0; URL='https://calendly.com/cylinder'" />
+</head>


### PR DESCRIPTION
Reason for Change
=================
* Looks nicer :)

Changes
=======
* Add an HTML redirect using a zero-timed refresh with a different URL