### PR TITLE
Revert "Update blog link"

### DIFF
--- a/source/partials/_navigation.html.slim
+++ b/source/partials/_navigation.html.slim
@@ -8,7 +8,7 @@ nav.nav--global
       .col-xs-6.col-sm-4
         .nav-links
           = link_to "Services", "#services"
-          = link_to "Blog", "https://medium.com/@cylinderdigital/latest", target: "_blank"
+          = link_to "Blog", "https://medium.com/cylinder-blog", target: "_blank"
           = link_to "Contact", "#contact"
 
         = link_to "Menu", "#", class: "menu-trigger"


### PR DESCRIPTION
* Turns out this was just a bit of a learning curve with Medium on how they associate posts with "publications".

This reverts commit a795f646c472a5e760f076500cec28bdad2b2606.