### PR TITLE
Fix broken CTAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@
 
 This is the
 marketing site for Cylinder,
-found at http://cylinder.work.
+found at http://cylinder.digital.
 
-It's built in Middlman
-using Proteus for configuration.
-We are deployed to GitHub Pages.
+It's built in [Middleman].
+We are deployed to [GitHub Pages].
+
+[Middleman]: https://middlemanapp.com
+[Github Pages]: https://pages.github.com
+
 
 
 ## About Middleman
@@ -37,8 +40,6 @@ Pages.
 * [Coffeescript](http://coffeescript.org):
   Write javascript with simpler syntax
 
-We also recommend [Refills](http://refills.bourbon.io/) for prepackaged interface patterns and [Proteus](http://github.com/thoughtbot/proteus) for a collection of useful
-starter kits to help you prototype faster.
 
 ## Getting Started
 
@@ -51,7 +52,8 @@ Install a Ruby manager like
 * [`chruby`](https://github.com/postmodern/chruby#install)
 * [`rvm`](https://github.com/rvm/rvm#installation)
 
-This repository uses Ruby version 2.3.1.
+This repository uses the Ruby version specified in the
+[.ruby-version](.ruby-version) file.
 
 ### Install dependencies
 ```

--- a/source/partials/_hero.html.slim
+++ b/source/partials/_hero.html.slim
@@ -4,7 +4,7 @@ header.hero
       .col-xs-12.col-sm-6
         h1.primary-heading We are Cylinder.
         h2.secondary-heading We solve business problems with digital products.
-        = link_to "Contact Us", "#contact-us", class: "button button--large button--white"
+        = link_to "Contact Us", "mailto:hello@cylinder.work", class: "button button--large button--white"
 
       .col-xs-12.col-sm-6.first-xs.last-sm
         = image_tag "illustration/hero-illustration.svg"

--- a/source/partials/_work-together.html.slim
+++ b/source/partials/_work-together.html.slim
@@ -5,7 +5,7 @@ section#contact.highlight-background
         h2.section-heading Let's work together!
         h3.secondary-heading Get in touch with us and we will contact you to discuss how we can help you solve business problems.
         .vertical-spacer
-        = link_to "Get In Touch", "http://eepurl.com/ch9l1D", class: "button button--large button--white"
+        = link_to "Get In Touch", "mailto:hello@cylinder.work", class: "button button--large button--white"
 
       .first-xs.col-xs-6.col-sm-5.last-sm
         = image_tag "illustration/contact-illustration.svg", width: "100%"


### PR DESCRIPTION
Reason for Change
=================
* The CTAs were not operating correctly or really doing much of anything.

Changes
=======
* Send the CTA buttons to `mailto:hello@cylinder.work`.

Minor
-----
* Updates to README.md to remove Proteus references.
* Correct website link in README.md
* Point to a ruby version file instead of live with something fragile in the documentation.