### PR TITLE
Prettier slug for The Cylinder Way

### DIFF
--- a/source/partials/_navigation.html.slim
+++ b/source/partials/_navigation.html.slim
@@ -9,7 +9,7 @@ nav.nav--global
         .nav-links
           = link_to "Services", "#services"
           = link_to "Blog", "https://medium.com/cylinder-blog", target: "_blank"
-          = link_to "Our Way", "resources/the_cylinder_way_v1.1.1.pdf"
+          = link_to "Our Way", "/way"
           = link_to "Contact", "#contact"
 
         = link_to "Menu", "#", class: "menu-trigger"

--- a/source/way.html.erb
+++ b/source/way.html.erb
@@ -1,0 +1,3 @@
+<head>
+  <meta http-equiv="refresh" content="0; URL='resources/the_cylinder_way_v1.1.1.pdf'" />
+</head>


### PR DESCRIPTION
Reason for Change
=================
* To make this more sharable, I wanted to have the PDF load from `http://cylinder.digital/way`.
* To have the short slug, we need an `.erb` template.
* The only way to have the template open the PDF is to use a refresh with redirect, as far as I can tell.

Changes
=======
* Add a `/way` page which opens the PDF.