### PR TITLE
Use absolute link for PDF

### DIFF
--- a/source/way.html.erb
+++ b/source/way.html.erb
@@ -1,3 +1,3 @@
 <head>
-  <meta http-equiv="refresh" content="0; URL='resources/the_cylinder_way_v1.1.1.pdf'" />
+  <meta http-equiv="refresh" content="0; URL='http://cylinder.digital/resources/the_cylinder_way_v1.1.1.pdf'" />
 </head>


### PR DESCRIPTION
Reason for Change
=================
* The Internet can be annoying.

Changes
=======
* Use the absolute URL for the document